### PR TITLE
send_mess() uses 'const char *'

### DIFF
--- a/micosApp/src/drvMicos.cc
+++ b/micosApp/src/drvMicos.cc
@@ -74,7 +74,7 @@ volatile int Micos_num_axis = 0;
 
 /*----------------functions-----------------*/
 static int recv_mess(int, char *, int);
-static RTN_STATUS send_mess(int, const char *, char *);
+static RTN_STATUS send_mess(int, const char *, const char *);
 static void start_status(int);
 static int set_status(int, int);
 static long report(int);
@@ -301,7 +301,7 @@ static int set_status(int card, int signal)
 /* send a message to the Micos board                 */
 /* send_mess()                                       */
 /*****************************************************/
-static RTN_STATUS send_mess(int card, const char *com, char *name)
+static RTN_STATUS send_mess(int card, const char *com, const char *name)
 {
     struct MicosController *cntrl;
     int size;


### PR DESCRIPTION
The 3rd parameter in send_mess(), "name" can and should
be a 'const char *' instead of just 'char *'.
Modern compilers complain here, so that the signature now
gets the const.

This is a minimal part of a series from Dirk Zimoch,
more warnings can be removed here and there.