### PR TITLE
Add missing include of epicsThread.h

### DIFF
--- a/micosApp/src/SMCTaurusAxis.cpp
+++ b/micosApp/src/SMCTaurusAxis.cpp
@@ -1,4 +1,5 @@
 
+#include <epicsThread.h>
 #include "SMCTaurusDriver.h"
 
 /** Creates a new SMCTaurusAxis object.

--- a/micosApp/src/SMChydraAxis.cpp
+++ b/micosApp/src/SMChydraAxis.cpp
@@ -1,4 +1,5 @@
 
+#include <epicsThread.h>
 #include "SMChydraDriver.h"
 
 /** Creates a new SMChydraAxis object.


### PR DESCRIPTION
Compiling against EPICS base 3.15 failed:
epicsThreadSleep() did not have a prototype.
Add missing include of epicsThread.h at 2 places.