### PR TITLE
SMCTaurusAxis: Mixup of controller and _controller

### DIFF
--- a/micosApp/src/SMCTaurusAxis.h
+++ b/micosApp/src/SMCTaurusAxis.h
@@ -28,7 +28,7 @@ public:
     void report(FILE *fp, int level);
 
 private:
-    SMCTaurusController* controller;
+    SMCTaurusController* controller_;
     asynStatus sendAccelAndVelocity(double accel, double velocity);
     int motorForm_;
     int polePairs_;


### PR DESCRIPTION
One compiler complaint, that "controller" may be not initialized in the constructor.
Rename "controller" into "controller_" in SMCTaurusAxis to follow the more common pattern that "class variable xyz" is named "xyz_" in the code and fix the contructor.